### PR TITLE
only read snippet and complain once

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,19 +23,21 @@ module.exports = {
   name: 'ember-segmentio',
 
   contentFor: function(type, config) {
-    var content = '';
-    var coreSnippet = readSnippet();
-    var enabled = config.SEGMENTIO_TOKEN && coreSnippet;
-
-    if (!config.SEGMENTIO_TOKEN) {
-      console.warn('ember-segmentio: Not enabled missing key "SEGMENTIO_TOKEN" in parent application/addon.');
-    }
-
-    if (!coreSnippet) {
-      console.warn('ember-segmentio: Error while reading snippet.');
-    }
 
     if (type === 'head') {
+
+      var content = '';
+
+      var coreSnippet = readSnippet();
+      var enabled = config.SEGMENTIO_TOKEN && coreSnippet;
+
+      if (!config.SEGMENTIO_TOKEN) {
+        console.warn('ember-segmentio: Not enabled missing key "SEGMENTIO_TOKEN" in parent application/addon.');
+      }
+
+      if (!coreSnippet) {
+        console.warn('ember-segmentio: Error while reading snippet.');
+      }
 
       var contentParts = [
         '<script type="text/javascript">',
@@ -54,9 +56,9 @@ module.exports = {
         '</script>'
       ]).join('');
 
+      return content;
     }
 
-    return content;
   }
 
 };


### PR DESCRIPTION
**Purpose**:
Has always warned over and over to user during ember build that `SEGMENTIO_TOKEN` is missing.
Need only mention it once.

**Approach**
Moves all logic into if statement looking for content head.

**Focus areas**

**Test coverage**
Manually tested use in Vishnu UI, with and without `SEGMENT_KEY` supplied 

**Analytics added or changed**

**Merge Dependencies and Related Work**

**Open Questions and Pre-Merge TODOs**
### Screenshots
#### Before

![image](https://cloud.githubusercontent.com/assets/89222/13901198/f788bd5a-edd8-11e5-81ba-b585222213d0.png)
#### After

![image](https://cloud.githubusercontent.com/assets/89222/13901202/1fb3b46a-edd9-11e5-8d3c-35552b7b49e1.png)
